### PR TITLE
chore(gemebuild): remove the re-imports map configuration

### DIFF
--- a/apps/gemebuild/src/app/page.tsx
+++ b/apps/gemebuild/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { HomeEn } from '@/i18n-pages/home'
+import { HomeEn } from '../i18n-pages/home'
 
 export default function Home() {
   return <HomeEn />

--- a/apps/gemebuild/tsconfig.json
+++ b/apps/gemebuild/tsconfig.json
@@ -6,10 +6,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
-    "isolatedModules": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "isolatedModules": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
The re-imports map config is not working when integrating the gemebuild into the geme.bio. This is focus gemebuild use relative imports to fix the issue.

cf: https://applink.feishu.cn/client/todo/detail?guid=234623ee-8337-4533-a5f2-1a45a53bda94&suite_entity_num=t105035