### PR TITLE
migrate/translation/manuals-download (迁移并翻译manuals-download的de、fr版本)

### DIFF
--- a/apps/gemebuild/src/components/table/index.tsx
+++ b/apps/gemebuild/src/components/table/index.tsx
@@ -1,0 +1,70 @@
+ 
+ export interface IDownloadFileTableProps{
+    name: string
+    description: string
+    files: Array<{ language: string; document: string; pdfLink: string }>
+    tableTitle: Array<string>
+ }
+
+ function DownloadFileTable({
+  name,
+  description,
+  files,
+  tableTitle,
+}: IDownloadFileTableProps) {
+  return (
+    <div className="mt-8 mb-8">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-xl font-semibold text-gray-900">{name}</h1>
+          <p className="mt-2 text-sm text-gray-700">{description}</p>
+        </div>
+      </div>
+      <div className="mt-8 flex flex-col">
+        <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
+            <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
+              <table className="min-w-full divide-y divide-gray-300">
+                <thead className="bg-gray-50">
+                  <tr>
+                    {tableTitle.map((title, index) => (
+                      <th
+                        key={title + index}
+                        scope="col"
+                        className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
+                      >
+                        {title}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="bg-white">
+                  {files.map((file, idx) => (
+                    <tr
+                      key={file.language}
+                      className={idx % 2 === 0 ? undefined : 'bg-gray-50'}
+                    >
+                      <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                        {file.language}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                        <a
+                          href={file.pdfLink}
+                          target="_blank"
+                          className="text-accent-6 hover:text-accent-9 transition ease-in-out duration-150 underline"
+                        >
+                          {file.document}
+                        </a>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+export default DownloadFileTable

--- a/apps/gemebuild/src/i18n-pages/manuals-download/components/ManualsDownload.tsx
+++ b/apps/gemebuild/src/i18n-pages/manuals-download/components/ManualsDownload.tsx
@@ -1,0 +1,20 @@
+import DownloadFileTable, { IDownloadFileTableProps } from '../../../components/table'
+
+export interface IManualsDownloadProps extends IDownloadFileTableProps{
+  title:string
+}
+
+const ManualsDownload = (props:IManualsDownloadProps) => {
+  return (
+    <div className="bg-gray-50">
+      <div className="mx-auto max-w-7xl  px-2 sm:px-6 py-12 lg:px-8">
+        <h2 className="text-4xl font-bold tracking-tight text-gray-900 mb-5 sm:mb-20 text-center">
+          {props.title}
+        </h2>
+        <DownloadFileTable {...props} />
+      </div>
+    </div>
+  )
+}
+
+export default ManualsDownload

--- a/apps/gemebuild/src/i18n-pages/manuals-download/de.tsx
+++ b/apps/gemebuild/src/i18n-pages/manuals-download/de.tsx
@@ -1,0 +1,40 @@
+import ManualsDownload from './components/ManualsDownload'
+import type { IManualsDownloadProps } from './components/ManualsDownload'
+import { unstable_setRequestLocale } from 'next-intl/server'
+
+// 静态页面的内容 配置文件 De版
+const manualsDownloadProps: IManualsDownloadProps = {
+  title: 'Manuals & Download',
+  name: 'Anleitungen',
+  description: `Die Bedienungsanleitung für Ihr GEME finden Sie hier.`,
+  files: [
+    {
+      language: 'Englisch',
+      document: 'geme-manual-en.pdf',
+      pdfLink: `/assets/return/geme-manual-en-v2.pdf`,
+    },
+    {
+      language: 'Französisch',
+      document: 'geme-manual-fr.pdf',
+      pdfLink: `/assets/return/geme-manual-fr.pdf`,
+    },
+    {
+      language: 'Deutsch',
+      document: 'geme-manual-de.pdf',
+      pdfLink: `/assets/return/geme-manual-de.pdf`,
+    },
+  ],
+  tableTitle: ['Sprache', 'Dokumentieren'],
+}
+
+function ManualsDownloadPageDe() {
+  const url = 'https://www.geme.bio/de/manuals-download'
+
+  return (
+    <>
+      <link rel="canonical" href={url} />
+      <ManualsDownload {...manualsDownloadProps} />
+    </>
+  )
+}
+export { ManualsDownloadPageDe }

--- a/apps/gemebuild/src/i18n-pages/manuals-download/en.tsx
+++ b/apps/gemebuild/src/i18n-pages/manuals-download/en.tsx
@@ -1,0 +1,41 @@
+import ManualsDownload from './components/ManualsDownload'
+import type { IManualsDownloadProps } from './components/ManualsDownload'
+import { unstable_setRequestLocale } from 'next-intl/server'
+
+// 静态页面的内容 配置文件 En版
+const manualsDownloadProps: IManualsDownloadProps = {
+  title: 'Manuals Download',
+  name: 'Manuals',
+  description: `You can find the user manual for your GEME here.`,
+  files: [
+    {
+      language: 'English',
+      document: 'geme-manual-en.pdf',
+      pdfLink: `/assets/return/geme-manual-en-v2.pdf`,
+    },
+    {
+      language: 'French',
+      document: 'geme-manual-fr.pdf',
+      pdfLink: `/assets/return/geme-manual-fr.pdf`,
+    },
+    {
+      language: 'German',
+      document: 'geme-manual-de.pdf',
+      pdfLink: `/assets/return/geme-manual-de.pdf`,
+    },
+  ],
+  tableTitle: ['Language', 'Document'],
+}
+
+
+function ManualsDownloadPageEn() {
+  const url = 'https://www.geme.bio/manuals-download'
+
+  return (
+    <>
+      <link rel="canonical" href={url} />
+      <ManualsDownload {...manualsDownloadProps} />
+    </>
+  )
+}
+export { ManualsDownloadPageEn }

--- a/apps/gemebuild/src/i18n-pages/manuals-download/fr.tsx
+++ b/apps/gemebuild/src/i18n-pages/manuals-download/fr.tsx
@@ -1,0 +1,41 @@
+import ManualsDownload from './components/ManualsDownload'
+import type { IManualsDownloadProps } from './components/ManualsDownload'
+import { unstable_setRequestLocale } from 'next-intl/server'
+
+// 静态页面的内容 配置文件 Fr版
+const manualsDownloadProps: IManualsDownloadProps = {
+  title: 'Téléchargement des manuels',
+  name: 'Manuels',
+  description: `Vous pouvez trouver le manuel d’utilisation de votre GEME ici.`,
+  files: [
+    {
+      language: 'Anglais',
+      document: 'geme-manual-en.pdf',
+      pdfLink: `/assets/return/geme-manual-en-v2.pdf`,
+    },
+    {
+      language: 'Français',
+      document: 'geme-manual-fr.pdf',
+      pdfLink: `/assets/return/geme-manual-fr.pdf`,
+    },
+    {
+      language: 'Allemand',
+      document: 'geme-manual-de.pdf',
+      pdfLink: `/assets/return/geme-manual-de.pdf`,
+    },
+  ],
+  tableTitle: ['Langue', 'Document'],
+}
+
+
+function ManualsDownloadPageFr() {
+  const url = 'https://www.geme.bio/fr/manuals-download'
+
+  return (
+    <>
+      <link rel="canonical" href={url} />
+      <ManualsDownload {...manualsDownloadProps} />
+    </>
+  )
+}
+export { ManualsDownloadPageFr }

--- a/apps/gemebuild/src/i18n-pages/manuals-download/index.stories.tsx
+++ b/apps/gemebuild/src/i18n-pages/manuals-download/index.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { ManualsDownloadPageDe, ManualsDownloadPageEn,ManualsDownloadPageFr } from '.'
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: 'Pages/maunals-download',
+} satisfies Meta<typeof ManualsDownloadPageEn>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const En: Story = {
+  name: 'en',
+  render: () => <ManualsDownloadPageEn />,
+}
+
+export const Fr: Story = {
+  name: 'fr',
+  render: () => <ManualsDownloadPageFr />,
+}
+
+export const De: Story = {
+  name: 'de',
+  render: () => <ManualsDownloadPageDe />,
+}

--- a/apps/gemebuild/src/i18n-pages/manuals-download/index.ts
+++ b/apps/gemebuild/src/i18n-pages/manuals-download/index.ts
@@ -1,0 +1,3 @@
+export { ManualsDownloadPageEn } from './en'
+export { ManualsDownloadPageFr } from './fr'
+export { ManualsDownloadPageDe } from './de'


### PR DESCRIPTION
migrate/translation/manuals-download (迁移并翻译manuals-download的de、fr版本)
https://applink.feishu.cn/client/todo/detail?guid=a10ef228-29a9-4ce8-9729-6ed89a6cf70c&suite_entity_num=t105323