### PR TITLE
fix-industrial-equipments-page-headline (修复德、法语版的industrial-equipments页的headline)

### DIFF
--- a/apps/gemebuild/src/i18n-pages/industrial-equipments/de.tsx
+++ b/apps/gemebuild/src/i18n-pages/industrial-equipments/de.tsx
@@ -9,7 +9,7 @@ import { mapItemsToProducts } from '../../helpers/industrial-equipments/tool'
 
 // Hero组件内容的配置数据  De版
 const heroConfigProps: IHeroWithImageTilesProps = {
-  title: 'SPIEL für Unternehmen',
+  title: 'GEME für das Geschäft',
   description: `Überall dort, wo Biomüll entsteht, verändert GEME die Welt.
   GEME unterschiedlicher Größe wird häufig in Gemeinden, Schulen, Krankenhäusern, Bürogebäuden, Einkaufszentren, Touristenattraktionen, Resorts, Restaurants, Hotels usw. eingesetzt.`,
   primaryButtonLabel: 'Kontaktiere uns',

--- a/apps/gemebuild/src/i18n-pages/industrial-equipments/fr.tsx
+++ b/apps/gemebuild/src/i18n-pages/industrial-equipments/fr.tsx
@@ -9,7 +9,7 @@ import { mapItemsToProducts } from '../../helpers/industrial-equipments/tool'
 
 // Hero组件内容的配置数据  Fr版
 const heroConfigProps: IHeroWithImageTilesProps = {
-  title: 'JEU pour les entreprises',
+  title: 'GEME pour le business',
   description: `Partout où des biodéchets sont générés, c'est là que GEME change le monde.
   Différentes tailles de GEME sont largement utilisées dans les communautés, les écoles, les hôpitaux, les immeubles de bureaux, les centres commerciaux, les attractions touristiques, les centres de villégiature, les restaurants, les hôtels, etc.`,
   primaryButtonLabel: 'Contactez-nous',


### PR DESCRIPTION
fix-industrial-equipments-page-headline (修复德、法语版的industrial-equipments页的headline)
https://applink.feishu.cn/client/todo/detail?guid=15e6197d-a17d-41ce-8626-54ef508f6f3d&suite_entity_num=t105371