### PR TITLE
delete undefined class

### DIFF
--- a/packages/ui/src/oxygen-cycle/animated-oxygen-cycle.tsx
+++ b/packages/ui/src/oxygen-cycle/animated-oxygen-cycle.tsx
@@ -23,7 +23,6 @@ function ScrollTriggeredAnimatedOxygenCycle(props: IOxygenCycleProps) {
       start="top top+=12%"
       end="bottom center-=10%"
       pin={true}
-      pinnedContainer=".sb-show-main"
       scrub={true}
       markers={false}
       onUpdate={onUpdate}


### PR DESCRIPTION
Element | String - If your ScrollTrigger's trigger/endTrigger element is INSIDE an element that gets pinned by another ScrollTrigger (pretty uncommon), that would cause the start/end positions to be thrown off by however long that pin lasts, so you can set the pinnedContainer to that parent/container element to have ScrollTrigger calculate those offsets accordingly. Again, this is very rarely needed. Important: nested pinning is not supported, so this feature is only for non-pinning ScrollTriggers

https://gsap.com/docs/v3/Plugins/ScrollTrigger/